### PR TITLE
/profile Command

### DIFF
--- a/SEChatModifications.user.js
+++ b/SEChatModifications.user.js
@@ -154,21 +154,22 @@ with_plugin("http://stackflair.com/jquery.livequery.js", function ($) {
     };
     
     var Storage = {
+    	storageName: window.location.pathname + 'chatHighlights', 
         add: function add(match) {
             var highlights = Storage.retrieveAll();
             // console.dir(highlights);
             if ($.inArray(match, highlights) < 0) {
                 highlights.push(match);
-                localStorage["chatHighlights"] = JSON.stringify(highlights);
+                localStorage[this.storageName] = JSON.stringify(highlights);
             }
         },
         remove: function remove(match) {
             var highlights = Storage.retrieveAll();
             highlights.splice($.inArray(match, highlights), 1);
-            localStorage["chatHighlights"] = JSON.stringify(highlights);
+            localStorage[this.storageName] = JSON.stringify(highlights);
         },
         retrieveAll: function retrieveAll() {
-            var highlights = localStorage["chatHighlights"];
+            var highlights = localStorage[this.storageName];
             if (highlights != null) {
                 highlights = JSON.parse(highlights);
             } else {


### PR DESCRIPTION
`/profile` command added. The command uses the SO API to get the profile information from any of the StackExchange sites. I've also added a `matchSite()` function that implements the below site matching functionality. This type of commands have lots of potentials, using the API to grab stuff like Questions, Tag info, etc. 

Syntax: `/profile [site] [display name]`

`[site]` will match for common abbreviations like SO, SF and NTI before defaulting to `site.stackexchange.com`. 
