### PR TITLE
Changing title on SE sites (to remove SEO favoured tag)

### DIFF
--- a/SEModifications.user.js
+++ b/SEModifications.user.js
@@ -427,5 +427,10 @@ with_jquery(function ($) {
 				return false;
 			});
 		}
+
+                // Changes the page title to be the question and the Stack Exchange site
+		$("#question-header a").text( function (i,str) {
+			document.title = str + ' - ' + $("#hlogo a").text();
+		});
 	});
 });


### PR DESCRIPTION
Hi,

I'm fairly new to github so forgive me if I'm doing anything wrong :) I've made an addition to the SEModifications user script. Basically, it will change the page title to '[Question Title] - [Stack Exchange Site]' rather than putting the primary tag at the front.

This makes it nicer to see questions when using multiple tabs on a browser and makes it handier to bookmark since you don't have 'javascript - ' or something similar at the start of the bookmark title.

Kind regards,
Jonathon
