### PR TITLE
UI improvement

### DIFF
--- a/SEKeyboardShortcuts.user.js
+++ b/SEKeyboardShortcuts.user.js
@@ -104,7 +104,7 @@ with_jquery(function ($) {
 			} else {
 				i = i % items.length;
 			}
-			selectedItem = items.css("padding", "5px").css("border", "1px solid " + $("#content").css("backgroundColor")).eq(i);
+			selectedItem = items.removeAttr("style").eq(i);
 			selectedItem.css("border", "1px dashed black");
 			if (!selectedItem.is(":fully-visible")) {
 				$.scrollTo(selectedItem);


### PR DESCRIPTION
Removed padding modification to add better look when navigating. 
I think the css had changed since the script was done. I've removed the padding section (.css() that was adding properties in order to restore the original layout) and replaced it by .removeAttr that deletes the style attribute, thus restoring the css file default values.

@TODO: find a way to avoid the 1x1 shifting when the border spawns
There is still a problem I can't figure out: the addition of the border induces a shift of 1 px down and 1px right.
