### PR TITLE
/jot command extended

### DIFF
--- a/SEChatModifications.user.js
+++ b/SEChatModifications.user.js
@@ -594,10 +594,14 @@ inject(livequery, bindas, expressions, function ($) {
 	// Define the snippet jotting command
 	ChatExtension.define('jot', function () {
 		var first = arguments[0],
+			second = arguments[1],
 			room = $('#roomname').text(),
 			insert, display;
 
-		if (isNumber(first)) {
+		if (isNumber(first) && second === '|') {
+			insert = 'http://' + window.location.host + '/transcript/message/' + first;
+			display = $.makeArray(arguments).slice(2).join(' ');
+		} else if (isNumber(first)) {
 			validate('number');
 
 			insert = 'http://' + window.location.hostnmae + '/transcript/message/' + first;


### PR DESCRIPTION
Yesterday, reading the trascript I had a thought like "I want to /jot this message". /jot [link] works just fine, except that it displays a link instead of text in clips. This way it's hard to remember which link is for which message. It would be convinient to /jot [id] | [Message to display in /clips]. I did that ;)
