### PR TITLE
Removed span.action_clip style

### DIFF
--- a/SEChatModifications.user.js
+++ b/SEChatModifications.user.js
@@ -1555,15 +1555,6 @@ inject(livequery, bindas, expressions, function ($) {
             'padding': '2px 4px 3px',
             'background-color': '#efefef'
         },
-        'span.action_clip': {
-            'display': 'inline-block',
-            'height': '11px',
-            'width': '12px',
-            'margin-right': '3px',
-            'padding': '0',
-            'background': '1px 0px url("http://or.sstatic.net/chat/img/leave-and-switch-icons.png") no-repeat',
-            'cursor': 'pointer'
-        },
         '.monologue .message:hover .timestamp' : {
             'visibility': 'hidden'
         },


### PR DESCRIPTION
The element doesn't exist, neither does the image
it makes reference to. Removing the style doesn't
impact on the normal function of the script.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rchern/stackexchangescripts/69)

<!-- Reviewable:end -->
