### PR TITLE
Handle links-for-invalid-sites comment submit

### DIFF
--- a/SECommentLinkHelper.user.js
+++ b/SECommentLinkHelper.user.js
@@ -70,8 +70,13 @@ inject(function ($) {
             if (Object.keys(questions).length || Object.keys(answers).length) {
                 request(questions, 'questions', callback);
                 request(answers, 'answers', callback);
-            } else {
-                submit.call(form.eq(0));
+            }
+            
+            if (lock < 0) {
+                // either no question and answer links were detected, *or* none of the
+                // links were for valid sites and so no AJAX requests were started.
+                // In either case we need to trigger the comment submit at this point.
+                submit();
             }
 
             link.lastIndex = 0;


### PR DESCRIPTION
It is possible for links to match the `links` regex but whose domain does not match the `validSites` regex.

In such cases, the comment box is never submitted, and a second attempt to do so results in a page reload. This change, checking for the lock status in the handler lets you detect both the 'no links found' and the 'no links for valid sites' cases, and submit the comment form directly.

This fixes #88 