### PR TITLE
Explicitly link to https://, not protocol-relative URLs

### DIFF
--- a/SECommentLinkHelper.user.js
+++ b/SECommentLinkHelper.user.js
@@ -133,7 +133,7 @@ inject(function ($) {
                                 url = '/q/' + id;
                             }
 
-                            return leading + '[' + escapeMarkdown(toText(post.title)) + '](//' + results[i].domain + url + ')';
+                            return leading + '[' + escapeMarkdown(toText(post.title)) + '](https://' + results[i].domain + url + ')';
                         });
                     }
                 }


### PR DESCRIPTION
Stack Exchange deliberately [does not support protocol-relative URLs](https://meta.stackexchange.com/q/291236), so generate canonical links with the `https://` protocol.

This fixes #86 