### PR TITLE
Trim and collapse whitespace

### DIFF
--- a/SECommentLinkHelper.user.js
+++ b/SECommentLinkHelper.user.js
@@ -133,7 +133,8 @@ inject(function ($) {
                                 url = '/q/' + id;
                             }
 
-                            return leading + '[' + escapeMarkdown(toText(post.title)) + '](//' + results[i].domain + url + ')';
+                            return leading + '[' +
+                            escapeMarkdown(cleanWhitespace(toText(post.title))) + '](//' + results[i].domain + url + ')';
                         });
                     }
                 }
@@ -154,6 +155,12 @@ inject(function ($) {
             span.innerHTML = html;
 
             return span.textContent;
+        }
+
+        function cleanWhitespace(text) {
+            // remove leading and trailing whitespace, collapse multiple spaces
+            // into one everywhere else.
+            return text.replace(/^\s+|\s+$/g, '').replace(/\s+/g, ' ');
         }
 
         function escapeMarkdown(text) {


### PR DESCRIPTION
Sometimes, titles have extra whitespace, something that's just a waste of space in a comment. Trim whitespace from the ends, and collapse multiple space characters into single spaces.

Fixes #84