### PR TITLE
Update the paste to upload to work with the new SE image uploading system

### DIFF
--- a/SEChatModifications.user.js
+++ b/SEChatModifications.user.js
@@ -1665,7 +1665,7 @@ inject(livequery, bindas, expressions, function ($) {
          type: 'POST'
       }).then(function(result)
       {
-         return (result.match(/https?:\/\/i\.stack\.imgur\.com\/[a-zA-Z0-9]+\.png/)||[''])[0].replace(/^http:/, 'https:');
+         return (result.match(/https?:\/\/i\.sstatic\.net\/[a-zA-Z0-9]+\.png/)||[''])[0].replace(/^http:/, 'https:');
       });
    }
 });


### PR DESCRIPTION
Now that imgur is no longer used, the userscript needs to return a link to the image hosting utility SE uses.